### PR TITLE
Fix color of mob level above plate when player levels up

### DIFF
--- a/GudaPlates.lua
+++ b/GudaPlates.lua
@@ -2676,8 +2676,9 @@ GudaPlatesEventFrame:SetScript("OnEvent", function()
 
     elseif event == "PLAYER_LEVEL_UP" then
         -- Update cached player level for difficulty colors
+        -- arg1 is the new level; pass it directly to avoid stale UnitLevel("player")
         if GudaPlates_Level then
-            GudaPlates_Level.UpdatePlayerLevel()
+            GudaPlates_Level.UpdatePlayerLevel(arg1)
         end
 
     -- SuperWoW UNIT_CASTEVENT handler (moved to GudaPlates_Castbar.lua)

--- a/GudaPlates_Level.lua
+++ b/GudaPlates_Level.lua
@@ -55,8 +55,13 @@ local ELITE_STRINGS = {
 local cachedPlayerLevel = UnitLevel("player") or 60
 
 -- Update cached player level (call on PLAYER_LEVEL_UP and PLAYER_ENTERING_WORLD)
-function GudaPlates_Level.UpdatePlayerLevel()
-    cachedPlayerLevel = UnitLevel("player") or 60
+-- newLevel: pass arg1 from PLAYER_LEVEL_UP to avoid stale UnitLevel("player") during the event
+function GudaPlates_Level.UpdatePlayerLevel(newLevel)
+    if newLevel and tonumber(newLevel) then
+        cachedPlayerLevel = tonumber(newLevel)
+    else
+        cachedPlayerLevel = UnitLevel("player") or 60
+    end
 end
 
 -- Get cached player level


### PR DESCRIPTION
The difficulty color of the mob's level above the plate was not updating whenever you level up. This PR fixes that